### PR TITLE
Open non-web links with an external app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Small Android app for getting notified (friends, messages and notifications) whi
 
 ## Changelog
 
+* _1.11.0_
+   * Open links to other apps (such as email and phone links) with the matching app
+
 * _1.10.1_
   * Upgrade API level for the Play Store to be happy
    * Add link to DontKillMyApp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "org.surrel.facebooknotifications"
         minSdkVersion 16
         targetSdkVersion 34
-        versionCode 14
-        versionName '1.10.1'
+        versionCode 15
+        versionName '1.11.0'
         buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
     }
     buildTypes {

--- a/app/src/main/java/org/surrel/facebooknotifications/MainActivity.java
+++ b/app/src/main/java/org/surrel/facebooknotifications/MainActivity.java
@@ -75,6 +75,24 @@ public class MainActivity extends Activity {
                 // Javascript URL injection is defined in UpdateService
                 webview.loadUrl("javascript:;");
             }
+
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                if (url == null) {
+                    return false;
+                }
+                if (url.startsWith("http://") || url.startsWith("https://")) {
+                    return false;
+                }
+                try {
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    view.getContext().startActivity(intent);
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }
         });
 
         WebSettings webSettings = webview.getSettings();


### PR DESCRIPTION
The WebView client does not override `shouldOverrideUrlLoading`, so non web links such as `mailto:` and `tel:` are swallowed by the WebView.

This adds `shouldOverrideUrlLoading` that keeps `http` and `https` navigation in the WebView as before and sends other schemes out to the system. The launch is wrapped in a try/catch so a missing handler does not crash the app.

Closes #43
