### PR TITLE
Fix build for F-Droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Small Android app for getting notified (friends, messages and notifications) whi
 
 ## Changelog
 
+* _1.11.1_
+  * Remove `foojay` for the dependencies for F-Droid to be able to build the app again.
+
 * _1.11.0_
    * Open links to other apps (such as email and phone links) with the matching app
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "org.surrel.facebooknotifications"
         minSdkVersion 16
         targetSdkVersion 34
-        versionCode 15
-        versionName '1.11.0'
+        versionCode 16
+        versionName '1.11.1'
         buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
     }
     buildTypes {

--- a/app/gradle/wrapper/gradle-wrapper.properties
+++ b/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Oct 21 11:34:03 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,1 @@
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
-}
 include ':app'


### PR DESCRIPTION
This PR tries to fix the build on F-Droid's side:

- Removal of foojay dependency resolver.
- Update the gradle wrapper for the :app module (and not only for the root.